### PR TITLE
Add more comprehensible register count

### DIFF
--- a/Classes/ViewHelpers/Event/SimultaneousRegistrationsViewHelper.php
+++ b/Classes/ViewHelpers/Event/SimultaneousRegistrationsViewHelper.php
@@ -42,10 +42,12 @@ class SimultaneousRegistrationsViewHelper extends AbstractViewHelper
         $event = $this->arguments['event'];
         $minPossibleRegistrations = 1;
         if ($event->getMaxParticipants() > 0 &&
-            $event->getMaxRegistrationsPerUser() >= $event->getFreePlaces() &&
-            !$event->getEnableWaitlist()
+            $event->getMaxRegistrationsPerUser() >= $event->getFreePlaces()
         ) {
-            $maxPossibleRegistrations = $event->getFreePlaces();
+            if( $event->getEnableWaitlist() && !$event->getFreePlaces() )
+                $maxPossibleRegistrations = $event->getMaxRegistrationsPerUser();
+            else 
+                $maxPossibleRegistrations = $event->getFreePlaces();
         } else {
             $maxPossibleRegistrations = $event->getMaxRegistrationsPerUser();
         }

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -42,6 +42,9 @@
 			<trans-unit id="tx_sfeventmgt_domain_model_event.freePlaces">
 				<source>Free places</source>
 			</trans-unit>
+			<trans-unit id="tx_sfeventmgt_domain_model_event.hasWaitlist">
+				<source>There is a waitlist</source>
+			</trans-unit>
 			<trans-unit id="tx_sfeventmgt_domain_model_event.price">
 				<source>Price</source>
 			</trans-unit>

--- a/Resources/Private/Templates/Event/Detail.html
+++ b/Resources/Private/Templates/Event/Detail.html
@@ -172,6 +172,15 @@
 			</div>
 			<div class="clear"></div>
 		</div>
+		
+		<f:if condition='{event.enableWaitlist} && {event.freePlaces}'>			
+			<div class="event-detail-row">
+				<div class="event-detail-label">
+					<f:translate key="tx_sfeventmgt_domain_model_event.hasWaitlist" />
+				</div>
+				<div class="clear"></div>
+			</div>
+		</f:if>
 
 		<div class="event-detail-row">
 			<div class="event-detail-label">


### PR DESCRIPTION
Add same behavior for event registering with and without, for number user on form select
It's a more accessible way to register, and not having the "bad surprise" being (afterwards) on waitlist